### PR TITLE
Added the value to the InvalidArgumentException message.

### DIFF
--- a/src/DataType/Enum.php
+++ b/src/DataType/Enum.php
@@ -34,7 +34,7 @@ abstract class Enum extends SimpleValueObject
     {
         if (!in_array($type, self::getConstList(), true)) {
             throw new \InvalidArgumentException(
-                sprintf('Provided value for %s is not valid', get_class($this))
+                sprintf('Provided value for %s is not valid: %s', get_class($this), $type)
             );
         }
     }


### PR DESCRIPTION
In order to make it easier to identify the value passed. 

Useful for processes that create a lot of Enum, like crons.
